### PR TITLE
Update the profile for the GE Motion Dimmer switches that was changed when the GE/Jasco code was merged with the main code.

### DIFF
--- a/Consolidated Drivers/zwave-switch/fingerprints.yml
+++ b/Consolidated Drivers/zwave-switch/fingerprints.yml
@@ -149,25 +149,25 @@ zwaveManufacturer:
     manufacturerId: 0x0063
     productType: 0x494D
     productId: 0x3031
-    deviceProfileName: ge-motionswitch-assoc
+    deviceProfileName: ge-motionswitch
   - id: "0063/494D/3032"
     deviceLabel: GE Motion Switch 26931
     manufacturerId: 0x0063
     productType: 0x494D
     productId: 0x3032
-    deviceProfileName: ge-motionswitch-assoc
+    deviceProfileName: ge-motionswitch
   - id: "0063/494D/3033"
     deviceLabel: GE Motion Dimmer 26932
     manufacturerId: 0x0063
     productType: 0x494D
     productId: 0x3033
-    deviceProfileName: ge-motiondimmer-assoc
+    deviceProfileName: ge-motiondimmer
   - id: "0063/494D/3034"
     deviceLabel: GE Motion Dimmer 26933
     manufacturerId: 0x0063
     productType: 0x494D
     productId: 0x3034
-    deviceProfileName: ge-motiondimmer-assoc
+    deviceProfileName: ge-motiondimmer
   - id: "0063/4952/3031"
     deviceLabel: GE Outlet 12721
     manufacturerId: 0x0063


### PR DESCRIPTION
The profile for the GE Motion Dimmer switches was changed from ge-dimmerswitch to ge-dimmerswitch-assoc when the GE/Jasco code was merged into the main z-wave switch code.  This broke the presentation for these devices in both the detailView and the Automations views.