### PR TITLE
feat(zwave-switch): Add automatable LED capabilities for GE/Jasco switches

### DIFF
--- a/Consolidated Drivers/zwave-switch/capabilities/platemusic11009/guideLightIntensity-presentation.json
+++ b/Consolidated Drivers/zwave-switch/capabilities/platemusic11009/guideLightIntensity-presentation.json
@@ -1,0 +1,85 @@
+{
+  "dashboard": {
+    "states": [
+      {
+        "label": "{{guideLightIntensity.value}}"
+      }
+    ],
+    "actions": [],
+    "basicPlus": []
+  },
+  "detailView": [
+    {
+      "label": "Guide Light Intensity",
+      "displayType": "list",
+      "list": {
+        "command": {
+          "name": "setGuideLightIntensity",
+          "alternatives": [
+            { "key": "1", "value": "1 - Lowest", "type": "active" },
+            { "key": "2", "value": "2", "type": "active" },
+            { "key": "3", "value": "3", "type": "active" },
+            { "key": "4", "value": "4 - Medium", "type": "active" },
+            { "key": "5", "value": "5", "type": "active" },
+            { "key": "6", "value": "6", "type": "active" },
+            { "key": "7", "value": "7 - Highest", "type": "active" }
+          ],
+          "argumentType": "string"
+        },
+        "state": {
+          "value": "guideLightIntensity.value",
+          "valueType": "string",
+          "alternatives": [
+            { "key": "1", "value": "1 - Lowest", "type": "active" },
+            { "key": "2", "value": "2", "type": "active" },
+            { "key": "3", "value": "3", "type": "active" },
+            { "key": "4", "value": "4 - Medium", "type": "active" },
+            { "key": "5", "value": "5", "type": "active" },
+            { "key": "6", "value": "6", "type": "active" },
+            { "key": "7", "value": "7 - Highest", "type": "active" }
+          ]
+        }
+      }
+    }
+  ],
+  "automation": {
+    "conditions": [
+      {
+        "label": "Guide Light Intensity",
+        "displayType": "list",
+        "list": {
+          "alternatives": [
+            { "key": "1", "value": "1 - Lowest", "type": "active" },
+            { "key": "2", "value": "2", "type": "active" },
+            { "key": "3", "value": "3", "type": "active" },
+            { "key": "4", "value": "4 - Medium", "type": "active" },
+            { "key": "5", "value": "5", "type": "active" },
+            { "key": "6", "value": "6", "type": "active" },
+            { "key": "7", "value": "7 - Highest", "type": "active" }
+          ],
+          "value": "guideLightIntensity.value",
+          "valueType": "string"
+        }
+      }
+    ],
+    "actions": [
+      {
+        "label": "Guide Light Intensity",
+        "displayType": "list",
+        "list": {
+          "alternatives": [
+            { "key": "1", "value": "1 - Lowest", "type": "active" },
+            { "key": "2", "value": "2", "type": "active" },
+            { "key": "3", "value": "3", "type": "active" },
+            { "key": "4", "value": "4 - Medium", "type": "active" },
+            { "key": "5", "value": "5", "type": "active" },
+            { "key": "6", "value": "6", "type": "active" },
+            { "key": "7", "value": "7 - Highest", "type": "active" }
+          ],
+          "command": "setGuideLightIntensity",
+          "argumentType": "string"
+        }
+      }
+    ]
+  }
+}

--- a/Consolidated Drivers/zwave-switch/capabilities/platemusic11009/guideLightIntensity.json
+++ b/Consolidated Drivers/zwave-switch/capabilities/platemusic11009/guideLightIntensity.json
@@ -1,0 +1,34 @@
+{
+  "name": "Guide Light Intensity",
+  "attributes": {
+    "guideLightIntensity": {
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "enum": ["1", "2", "3", "4", "5", "6", "7"]
+          }
+        },
+        "additionalProperties": false,
+        "required": ["value"]
+      },
+      "setter": "setGuideLightIntensity"
+    }
+  },
+  "commands": {
+    "setGuideLightIntensity": {
+      "name": "setGuideLightIntensity",
+      "arguments": [
+        {
+          "name": "guideLightIntensity",
+          "optional": false,
+          "schema": {
+            "type": "string",
+            "enum": ["1", "2", "3", "4", "5", "6", "7"]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Consolidated Drivers/zwave-switch/capabilities/platemusic11009/ledIndicatorStatus-presentation.json
+++ b/Consolidated Drivers/zwave-switch/capabilities/platemusic11009/ledIndicatorStatus-presentation.json
@@ -1,0 +1,71 @@
+{
+  "dashboard": {
+    "states": [
+      {
+        "label": "{{ledIndicatorStatus.value}}"
+      }
+    ],
+    "actions": [],
+    "basicPlus": []
+  },
+  "detailView": [
+    {
+      "label": "LED Indicator",
+      "displayType": "list",
+      "list": {
+        "command": {
+          "name": "setLedIndicatorStatus",
+          "alternatives": [
+            { "key": "whenOff", "value": "On when switch off", "type": "active" },
+            { "key": "whenOn", "value": "On when switch on", "type": "active" },
+            { "key": "alwaysOff", "value": "Always off", "type": "active" },
+            { "key": "alwaysOn", "value": "Always on", "type": "active" }
+          ],
+          "argumentType": "string"
+        },
+        "state": {
+          "value": "ledIndicatorStatus.value",
+          "valueType": "string",
+          "alternatives": [
+            { "key": "whenOff", "value": "On when switch off", "type": "active" },
+            { "key": "whenOn", "value": "On when switch on", "type": "active" },
+            { "key": "alwaysOff", "value": "Always off", "type": "active" },
+            { "key": "alwaysOn", "value": "Always on", "type": "active" }
+          ]
+        }
+      }
+    }
+  ],
+  "automation": {
+    "conditions": [
+      {
+        "label": "LED Indicator",
+        "displayType": "list",
+        "list": {
+          "alternatives": [
+            { "key": "whenOff", "value": "On when switch off", "type": "active" },
+            { "key": "whenOn", "value": "On when switch on", "type": "active" },
+            { "key": "alwaysOff", "value": "Always off", "type": "active" },
+            { "key": "alwaysOn", "value": "Always on", "type": "active" }
+          ],
+          "value": "ledIndicatorStatus.value",
+          "valueType": "string"
+        }
+      }
+    ],
+    "actions": [
+      {
+        "label": "LED Indicator",
+        "displayType": "list",
+        "list": {
+          "alternatives": [
+            { "key": "whenOff", "value": "On when switch off", "type": "active" },
+            { "key": "whenOn", "value": "On when switch on", "type": "active" },
+            { "key": "alwaysOff", "value": "Always off", "type": "active" },
+            { "key": "alwaysOn", "value": "Always on", "type": "active" }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/Consolidated Drivers/zwave-switch/capabilities/platemusic11009/ledIndicatorStatus.json
+++ b/Consolidated Drivers/zwave-switch/capabilities/platemusic11009/ledIndicatorStatus.json
@@ -1,0 +1,44 @@
+{
+  "name": "LED Indicator Status",
+  "attributes": {
+    "ledIndicatorStatus": {
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "enum": ["whenOff", "whenOn", "alwaysOff", "alwaysOn"]
+          }
+        },
+        "additionalProperties": false,
+        "required": ["value"]
+      },
+      "setter": "setLedIndicatorStatus",
+      "enumCommands": [
+        { "command": "whenOff", "value": "whenOff" },
+        { "command": "whenOn", "value": "whenOn" },
+        { "command": "alwaysOff", "value": "alwaysOff" },
+        { "command": "alwaysOn", "value": "alwaysOn" }
+      ]
+    }
+  },
+  "commands": {
+    "setLedIndicatorStatus": {
+      "name": "setLedIndicatorStatus",
+      "arguments": [
+        {
+          "name": "ledIndicatorStatus",
+          "optional": false,
+          "schema": {
+            "type": "string",
+            "enum": ["whenOff", "whenOn", "alwaysOff", "alwaysOn"]
+          }
+        }
+      ]
+    },
+    "whenOff": { "name": "whenOff", "arguments": [] },
+    "whenOn": { "name": "whenOn", "arguments": [] },
+    "alwaysOff": { "name": "alwaysOff", "arguments": [] },
+    "alwaysOn": { "name": "alwaysOn", "arguments": [] }
+  }
+}

--- a/Consolidated Drivers/zwave-switch/capabilities/platemusic11009/ledLightColor-presentation.json
+++ b/Consolidated Drivers/zwave-switch/capabilities/platemusic11009/ledLightColor-presentation.json
@@ -1,0 +1,89 @@
+{
+  "dashboard": {
+    "states": [
+      {
+        "label": "{{ledLightColor.value}}"
+      }
+    ],
+    "actions": [],
+    "basicPlus": []
+  },
+  "detailView": [
+    {
+      "label": "LED Color",
+      "displayType": "list",
+      "list": {
+        "command": {
+          "name": "setLedLightColor",
+          "alternatives": [
+            { "key": "red", "value": "Red", "type": "active" },
+            { "key": "orange", "value": "Orange", "type": "active" },
+            { "key": "yellow", "value": "Yellow", "type": "active" },
+            { "key": "green", "value": "Green", "type": "active" },
+            { "key": "blue", "value": "Blue", "type": "active" },
+            { "key": "pink", "value": "Pink", "type": "active" },
+            { "key": "purple", "value": "Purple", "type": "active" },
+            { "key": "white", "value": "White", "type": "active" }
+          ],
+          "argumentType": "string"
+        },
+        "state": {
+          "value": "ledLightColor.value",
+          "valueType": "string",
+          "alternatives": [
+            { "key": "red", "value": "Red", "type": "active" },
+            { "key": "orange", "value": "Orange", "type": "active" },
+            { "key": "yellow", "value": "Yellow", "type": "active" },
+            { "key": "green", "value": "Green", "type": "active" },
+            { "key": "blue", "value": "Blue", "type": "active" },
+            { "key": "pink", "value": "Pink", "type": "active" },
+            { "key": "purple", "value": "Purple", "type": "active" },
+            { "key": "white", "value": "White", "type": "active" }
+          ]
+        }
+      }
+    }
+  ],
+  "automation": {
+    "conditions": [
+      {
+        "label": "LED Color",
+        "displayType": "list",
+        "list": {
+          "alternatives": [
+            { "key": "red", "value": "Red", "type": "active" },
+            { "key": "orange", "value": "Orange", "type": "active" },
+            { "key": "yellow", "value": "Yellow", "type": "active" },
+            { "key": "green", "value": "Green", "type": "active" },
+            { "key": "blue", "value": "Blue", "type": "active" },
+            { "key": "pink", "value": "Pink", "type": "active" },
+            { "key": "purple", "value": "Purple", "type": "active" },
+            { "key": "white", "value": "White", "type": "active" }
+          ],
+          "value": "ledLightColor.value",
+          "valueType": "string"
+        }
+      }
+    ],
+    "actions": [
+      {
+        "label": "LED Color",
+        "displayType": "list",
+        "list": {
+          "alternatives": [
+            { "key": "red", "value": "Red", "type": "active" },
+            { "key": "orange", "value": "Orange", "type": "active" },
+            { "key": "yellow", "value": "Yellow", "type": "active" },
+            { "key": "green", "value": "Green", "type": "active" },
+            { "key": "blue", "value": "Blue", "type": "active" },
+            { "key": "pink", "value": "Pink", "type": "active" },
+            { "key": "purple", "value": "Purple", "type": "active" },
+            { "key": "white", "value": "White", "type": "active" }
+          ],
+          "command": "setLedLightColor",
+          "argumentType": "string"
+        }
+      }
+    ]
+  }
+}

--- a/Consolidated Drivers/zwave-switch/capabilities/platemusic11009/ledLightColor.json
+++ b/Consolidated Drivers/zwave-switch/capabilities/platemusic11009/ledLightColor.json
@@ -1,0 +1,52 @@
+{
+  "name": "LED Light Color",
+  "attributes": {
+    "ledLightColor": {
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "enum": ["red", "orange", "yellow", "green", "blue", "pink", "purple", "white"]
+          }
+        },
+        "additionalProperties": false,
+        "required": ["value"]
+      },
+      "setter": "setLedLightColor",
+      "enumCommands": [
+        { "command": "red", "value": "red" },
+        { "command": "orange", "value": "orange" },
+        { "command": "yellow", "value": "yellow" },
+        { "command": "green", "value": "green" },
+        { "command": "blue", "value": "blue" },
+        { "command": "pink", "value": "pink" },
+        { "command": "purple", "value": "purple" },
+        { "command": "white", "value": "white" }
+      ]
+    }
+  },
+  "commands": {
+    "setLedLightColor": {
+      "name": "setLedLightColor",
+      "arguments": [
+        {
+          "name": "ledLightColor",
+          "optional": false,
+          "schema": {
+            "type": "string",
+            "enum": ["red", "orange", "yellow", "green", "blue", "pink", "purple", "white"]
+          }
+        }
+      ]
+    },
+    "red": { "name": "red", "arguments": [] },
+    "orange": { "name": "orange", "arguments": [] },
+    "yellow": { "name": "yellow", "arguments": [] },
+    "green": { "name": "green", "arguments": [] },
+    "blue": { "name": "blue", "arguments": [] },
+    "pink": { "name": "pink", "arguments": [] },
+    "purple": { "name": "purple", "arguments": [] },
+    "white": { "name": "white", "arguments": [] }
+  }
+}

--- a/Consolidated Drivers/zwave-switch/capabilities/platemusic11009/ledLightIntensity-presentation.json
+++ b/Consolidated Drivers/zwave-switch/capabilities/platemusic11009/ledLightIntensity-presentation.json
@@ -1,0 +1,85 @@
+{
+  "dashboard": {
+    "states": [
+      {
+        "label": "{{ledLightIntensity.value}}"
+      }
+    ],
+    "actions": [],
+    "basicPlus": []
+  },
+  "detailView": [
+    {
+      "label": "LED Intensity",
+      "displayType": "list",
+      "list": {
+        "command": {
+          "name": "setLedLightIntensity",
+          "alternatives": [
+            { "key": "1", "value": "1 - Lowest", "type": "active" },
+            { "key": "2", "value": "2", "type": "active" },
+            { "key": "3", "value": "3", "type": "active" },
+            { "key": "4", "value": "4 - Medium", "type": "active" },
+            { "key": "5", "value": "5", "type": "active" },
+            { "key": "6", "value": "6", "type": "active" },
+            { "key": "7", "value": "7 - Highest", "type": "active" }
+          ],
+          "argumentType": "string"
+        },
+        "state": {
+          "value": "ledLightIntensity.value",
+          "valueType": "string",
+          "alternatives": [
+            { "key": "1", "value": "1 - Lowest", "type": "active" },
+            { "key": "2", "value": "2", "type": "active" },
+            { "key": "3", "value": "3", "type": "active" },
+            { "key": "4", "value": "4 - Medium", "type": "active" },
+            { "key": "5", "value": "5", "type": "active" },
+            { "key": "6", "value": "6", "type": "active" },
+            { "key": "7", "value": "7 - Highest", "type": "active" }
+          ]
+        }
+      }
+    }
+  ],
+  "automation": {
+    "conditions": [
+      {
+        "label": "LED Intensity",
+        "displayType": "list",
+        "list": {
+          "alternatives": [
+            { "key": "1", "value": "1 - Lowest", "type": "active" },
+            { "key": "2", "value": "2", "type": "active" },
+            { "key": "3", "value": "3", "type": "active" },
+            { "key": "4", "value": "4 - Medium", "type": "active" },
+            { "key": "5", "value": "5", "type": "active" },
+            { "key": "6", "value": "6", "type": "active" },
+            { "key": "7", "value": "7 - Highest", "type": "active" }
+          ],
+          "value": "ledLightIntensity.value",
+          "valueType": "string"
+        }
+      }
+    ],
+    "actions": [
+      {
+        "label": "LED Intensity",
+        "displayType": "list",
+        "list": {
+          "alternatives": [
+            { "key": "1", "value": "1 - Lowest", "type": "active" },
+            { "key": "2", "value": "2", "type": "active" },
+            { "key": "3", "value": "3", "type": "active" },
+            { "key": "4", "value": "4 - Medium", "type": "active" },
+            { "key": "5", "value": "5", "type": "active" },
+            { "key": "6", "value": "6", "type": "active" },
+            { "key": "7", "value": "7 - Highest", "type": "active" }
+          ],
+          "command": "setLedLightIntensity",
+          "argumentType": "string"
+        }
+      }
+    ]
+  }
+}

--- a/Consolidated Drivers/zwave-switch/capabilities/platemusic11009/ledLightIntensity.json
+++ b/Consolidated Drivers/zwave-switch/capabilities/platemusic11009/ledLightIntensity.json
@@ -1,0 +1,34 @@
+{
+  "name": "LED Light Intensity",
+  "attributes": {
+    "ledLightIntensity": {
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "enum": ["1", "2", "3", "4", "5", "6", "7"]
+          }
+        },
+        "additionalProperties": false,
+        "required": ["value"]
+      },
+      "setter": "setLedLightIntensity"
+    }
+  },
+  "commands": {
+    "setLedLightIntensity": {
+      "name": "setLedLightIntensity",
+      "arguments": [
+        {
+          "name": "ledLightIntensity",
+          "optional": false,
+          "schema": {
+            "type": "string",
+            "enum": ["1", "2", "3", "4", "5", "6", "7"]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Consolidated Drivers/zwave-switch/profiles/ge-dimmer-scene.yml
+++ b/Consolidated Drivers/zwave-switch/profiles/ge-dimmer-scene.yml
@@ -4,6 +4,8 @@ components:
   capabilities:
   - id: switch
     version: 1
+  - id: platemusic11009.ledIndicatorStatus
+    version: 1
   - id: switchLevel
     version: 1
   - id: button

--- a/Consolidated Drivers/zwave-switch/profiles/ge-fan-scene-v2.yml
+++ b/Consolidated Drivers/zwave-switch/profiles/ge-fan-scene-v2.yml
@@ -4,6 +4,8 @@ components:
   capabilities:
   - id: switch
     version: 1
+  - id: platemusic11009.ledIndicatorStatus
+    version: 1
   - id: switchLevel
     version: 1    
   - id: fanSpeed

--- a/Consolidated Drivers/zwave-switch/profiles/ge-fan-scene.yml
+++ b/Consolidated Drivers/zwave-switch/profiles/ge-fan-scene.yml
@@ -4,6 +4,8 @@ components:
   capabilities:
   - id: switch
     version: 1
+  - id: platemusic11009.ledIndicatorStatus
+    version: 1
   - id: switchLevel
     version: 1
   - id: fanSpeed

--- a/Consolidated Drivers/zwave-switch/profiles/ge-outlet-scene.yml
+++ b/Consolidated Drivers/zwave-switch/profiles/ge-outlet-scene.yml
@@ -4,6 +4,8 @@ components:
   capabilities:
   - id: switch
     version: 1
+  - id: platemusic11009.ledIndicatorStatus
+    version: 1
   - id: button
     version: 1
   - id: firmwareUpdate

--- a/Consolidated Drivers/zwave-switch/profiles/ge-plugin-scene.yml
+++ b/Consolidated Drivers/zwave-switch/profiles/ge-plugin-scene.yml
@@ -4,6 +4,8 @@ components:
   capabilities:
   - id: switch
     version: 1
+  - id: platemusic11009.ledIndicatorStatus
+    version: 1
   - id: button
     version: 1
   - id: firmwareUpdate

--- a/Consolidated Drivers/zwave-switch/profiles/ge-switch-scene-led.yml
+++ b/Consolidated Drivers/zwave-switch/profiles/ge-switch-scene-led.yml
@@ -8,6 +8,14 @@ components:
     version: 1
   - id: platemusic11009.deviceNetworkId
     version: 1
+  - id: platemusic11009.ledIndicatorStatus
+    version: 1
+  - id: platemusic11009.ledLightColor
+    version: 1
+  - id: platemusic11009.ledLightIntensity
+    version: 1
+  - id: platemusic11009.guideLightIntensity
+    version: 1
   - id: firmwareUpdate
     version: 1
   - id: refresh

--- a/Consolidated Drivers/zwave-switch/profiles/ge-switch-scene.yml
+++ b/Consolidated Drivers/zwave-switch/profiles/ge-switch-scene.yml
@@ -4,6 +4,8 @@ components:
   capabilities:
   - id: switch
     version: 1
+  - id: platemusic11009.ledIndicatorStatus
+    version: 1
   - id: button
     version: 1
   - id: platemusic11009.deviceNetworkId

--- a/Consolidated Drivers/zwave-switch/src/init.lua
+++ b/Consolidated Drivers/zwave-switch/src/init.lua
@@ -26,6 +26,17 @@ customCap.firmware= {}
 customCap.firmware.name = "platemusic11009.firmware"
 customCap.firmware.capability = capabilities[customCap.firmware.name]
 
+-- LED Light capabilities (added by BigThunderSR)
+customCap.ledLightColor = {}
+customCap.ledLightColor.name = "platemusic11009.ledLightColor"
+customCap.ledLightColor.capability = capabilities[customCap.ledLightColor.name]
+customCap.ledLightIntensity = {}
+customCap.ledLightIntensity.name = "platemusic11009.ledLightIntensity"
+customCap.ledLightIntensity.capability = capabilities[customCap.ledLightIntensity.name]
+customCap.guideLightIntensity = {}
+customCap.guideLightIntensity.name = "platemusic11009.guideLightIntensity"
+customCap.guideLightIntensity.capability = capabilities[customCap.guideLightIntensity.name]
+
 --- Map component to en_point
 ---
 --- @param device st.zwave.Device


### PR DESCRIPTION
## ⚠️ Required: Register Capabilities with SmartThings

The capability JSON files are included in `capabilities/platemusic11009/`, but they must be **registered with SmartThings API** under your account before the driver will work.

```bash
# Register capabilities (from Consolidated Drivers/zwave-switch/)
smartthings capabilities:create -i capabilities/platemusic11009/ledIndicatorStatus.json
smartthings capabilities:create -i capabilities/platemusic11009/ledLightColor.json
smartthings capabilities:create -i capabilities/platemusic11009/ledLightIntensity.json
smartthings capabilities:create -i capabilities/platemusic11009/guideLightIntensity.json

# Register presentations
smartthings capabilities:presentation:create platemusic11009.ledIndicatorStatus 1 -i capabilities/platemusic11009/ledIndicatorStatus-presentation.json
smartthings capabilities:presentation:create platemusic11009.ledLightColor 1 -i capabilities/platemusic11009/ledLightColor-presentation.json
smartthings capabilities:presentation:create platemusic11009.ledLightIntensity 1 -i capabilities/platemusic11009/ledLightIntensity-presentation.json
smartthings capabilities:presentation:create platemusic11009.guideLightIntensity 1 -i capabilities/platemusic11009/guideLightIntensity-presentation.json
```

## Summary

This PR adds custom capabilities to expose LED settings as **automatable controls** for GE/Jasco/Honeywell/UltraPro Z-Wave switches. Currently these settings are only configurable via device preferences - this change allows them to be controlled via SmartThings automations and routines.

## New Capabilities

| Capability | Parameter | Options |
|------------|-----------|---------|
| `ledIndicatorStatus` | 3 | When On, When Off, Always Off, Always On |
| `ledLightColor` | 34 | Red, Orange, Yellow, Green, Blue, Pink, Purple, White |
| `ledLightIntensity` | 35 | Levels 1-7 |
| `guideLightIntensity` | 36 | Levels 1-7 |

## Changes

- **capabilities/platemusic11009/**: Added 8 capability definition files (4 capabilities × 2 files each)
- **profiles/ge-*-scene*.yml**: Added `ledIndicatorStatus` to 7 scene profiles
- **profiles/ge-switch-scene-led.yml**: Added all 4 LED capabilities
- **src/init.lua**: Added capability definitions
- **src/ge-switch/init.lua**: Added handlers for LED capability commands and configuration reports

## Profile Coverage

**LED Indicator Status only (7 profiles):**
- ge-dimmer-scene, ge-fan-scene, ge-fan-scene-v2, ge-outlet-scene, ge-plugin-scene, ge-switch-scene, ge-switch-scene-led

**Full LED Controls (1 profile):**
- ge-switch-scene-led (color, intensity, guide light)

**Not included:** Legacy and assoc profiles only support 3 Parameter 3 options (no 'Always On'), so `ledIndicatorStatus` was not added to avoid incompatibility.

## Testing

**Full LED Controls (ge-switch-scene-led profile):**
Tested on GE Smart Toggle Switch 58436 (0063/4952/3330):
- ✅ LED Color, Intensity, and Guide Light controls work correctly
- ✅ Values sync when changed from device or app
- ✅ Can be triggered via SmartThings automations

**LED Indicator Status (ge-switch-scene, ge-dimmer-scene profiles):**
Tested on GE Switch 46202 and GE Dimmer 46204:
- ✅ LED Indicator Status shows on main screen
- ✅ All 4 options work correctly
- ✅ Can be triggered via SmartThings automations

---

*This PR was developed with assistance from GitHub Copilot (Claude).*